### PR TITLE
Make engine initialization compatible with Spree 4.5.3

### DIFF
--- a/lib/spree_paypal_express/engine.rb
+++ b/lib/spree_paypal_express/engine.rb
@@ -19,7 +19,7 @@ module SpreePaypalExpress
 
     config.to_prepare &method(:activate).to_proc
 
-    initializer "spree.paypal_express.payment_methods", :after => "spree.register.payment_methods" do |app|
+    config.after_initialize do |app|
       app.config.spree.payment_methods << Spree::Gateway::PayPalExpress
     end
   end


### PR DESCRIPTION
### Summary
Use config.after_initialize, as other Spree gems, so that objects are available